### PR TITLE
feat: Add Discord notification workflow for PRs

### DIFF
--- a/.github/workflows/discord-notifs.yml
+++ b/.github/workflows/discord-notifs.yml
@@ -1,0 +1,24 @@
+name: PR Notifications
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send embed notification to Discord
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: |
+            📢 **New Pull Request Ready for Review!**
+            • **Repository:** ${{ github.repository }}
+            • **Title:** ${{ github.event.pull_request.title }}
+            • **Author:** ${{ github.event.pull_request.user.login }}
+            • **Branch:** `${{ github.event.pull_request.head.ref }}`
+            • **Base:** `${{ github.event.pull_request.base.ref }}`
+
+            🔗 ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate notifications for pull requests. The workflow sends an embed notification to a Discord channel whenever a pull request is opened or marked as ready for review.

**New workflow for PR notifications:**

* Added `.github/workflows/discord-notifs.yml` to send Discord notifications for pull request events (`opened`, `ready_for_review`) using the `Ilshidur/action-discord` GitHub Action. The notification includes repository, PR title, author, branch, base, and a link to the PR.